### PR TITLE
Benching extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 name = "polkadot-ckb-merkle-mountain-range"
 version = "0.8.0"
 authors = [
-	"Nervos Core Dev <dev@nervos.org>",
-	"Parity Technologies <admin@parity.io>",
-	"Robert Hambrock <roberthambrock@gmail.com>"
+    "Nervos Core Dev <dev@nervos.org>",
+    "Parity Technologies <admin@parity.io>",
+    "Robert Hambrock <roberthambrock@gmail.com>",
 ]
 
 edition = "2018"
@@ -14,11 +14,14 @@ repository = "https://github.com/paritytech/merkle-mountain-range"
 
 [features]
 default = ["std"]
+production-bench = []
 std = []
 
 [dependencies]
 cfg-if = "1.0"
-itertools = {version = "0.10.5", default-features = false, features = ["use_alloc"]}
+itertools = { version = "0.10.5", default-features = false, features = [
+    "use_alloc",
+] }
 
 [dev-dependencies]
 faster-hex = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,45 @@ The merkle proof is an array of hashes constructed with the following parts:
 
 We can reconstruct the merkle root from the proofs. Pre-calculating the peak positions from the size of MMR may help us do the bagging.
 
+## Benchmarks
+
+The default benchmarks can be run with
+```bash
+cargo bench
+```
+
+The results is stored in `target/criterion` and for instance be viewed in the generated HTML report at `target/criterion/report/index.html`.
+
+To compare benchmark results between git revisions `baseline_rev` and `update_rev`:
+```bash
+# Run & save benchmarks on baseline revision
+git checkout $baseline_rev
+cargo bench --bench mmr_benchmark -- --save-baseline $baseline_rev
+
+# Switch to updated revision, run & save benchmarks
+git checkout $update_rev
+cargo bench --bench mmr_benchmark -- --save-baseline $update_rev
+
+# Optional: Compare results with critcmp
+cargo install critcmp  # if not already installed
+# critcmp orders benchmarks lexicographically by benchmark name
+echo baseline: $baseline_rev
+echo update: $update_rev
+echo -----
+critcmp $baseline_rev $update_rev
+```
+
+## Production Benchmarks
+
+For routine development and testing, the default benchmarks (200K leaves) should be sufficient.
+If making changes to the MMR logic (generation or proofs), to avoid performance regressions at production scale, it's recommended to run the MMR benchmarks with much higher MMR sizes before merging changes.benchmarks at production scale before merging changes.
+For Polkadot/Kusama a production scale of 40M leaves is appropriate - this can be benched using the `production-bench` feature:
+```bash
+cargo bench --features production-bench
+```
+
+**Note:** This scale may take hours to complete and requires substantial memory, approximately 12GB peak RAM usage for the MMR tests.
+
 ## References
 
 * [Merkle mountain range](https://github.com/opentimestamps/opentimestamps-server/blob/master/doc/merkle-mountain-range.md)

--- a/benches/mmr_benchmark.rs
+++ b/benches/mmr_benchmark.rs
@@ -112,7 +112,7 @@ fn bench(c: &mut Criterion) {
         b.iter(|| {
             mmr.gen_node_proof(
                 positions
-                    .choose_multiple(&mut rng, 1_000)
+                    .choose_multiple(&mut rng, 2_000_000)
                     .cloned()
                     .collect::<Vec<_>>(),
             )
@@ -174,11 +174,11 @@ fn bench(c: &mut Criterion) {
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         let root: NumberHash = mmr.get_root().unwrap();
-        let proofs: Vec<_> = (0..500)
+        let proofs: Vec<_> = (0..100)
             .map(|i| {
                 // choose multiple positions from the MMR
                 let pos_sample: Vec<u64> = positions
-                    .choose_multiple(&mut rng, 1_000)
+                    .choose_multiple(&mut rng, 200_000)
                     .cloned()
                     .collect();
                 let elems = pos_sample

--- a/benches/mmr_benchmark.rs
+++ b/benches/mmr_benchmark.rs
@@ -105,14 +105,14 @@ fn bench(c: &mut Criterion) {
         b.iter(|| mmr.gen_node_proof(vec![*positions.choose(&mut rng).unwrap()]));
     });
 
-    c.bench_function("MMR gen node-proof batch", |b| {
+    c.bench_function("MMR gen batch node-proof", |b| {
         let (mmr_size, store, positions) = prepare_mmr_no_roots(20_000_000);
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         b.iter(|| {
             mmr.gen_node_proof(
                 positions
-                    .choose_multiple(&mut rng, 100_000)
+                    .choose_multiple(&mut rng, 1_000)
                     .cloned()
                     .collect::<Vec<_>>(),
             )
@@ -174,11 +174,11 @@ fn bench(c: &mut Criterion) {
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         let root: NumberHash = mmr.get_root().unwrap();
-        let proofs: Vec<_> = (0..100_000)
-            .map(|_| {
+        let proofs: Vec<_> = (0..500)
+            .map(|i| {
                 // choose multiple positions from the MMR
                 let pos_sample: Vec<u64> = positions
-                    .choose_multiple(&mut rng, 100_000)
+                    .choose_multiple(&mut rng, 1_000)
                     .cloned()
                     .collect();
                 let elems = pos_sample

--- a/benches/mmr_benchmark.rs
+++ b/benches/mmr_benchmark.rs
@@ -92,32 +92,32 @@ const INDEX_DOMAIN: u64 = 2_000;
 
 fn bench(c: &mut Criterion) {
     c.bench_function("MMR gen proof", |b| {
-        let (mmr_size, store, positions) = prepare_mmr_no_roots(100_000);
+        let (mmr_size, store, positions) = prepare_mmr_no_roots(20_000_000);
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         b.iter(|| mmr.gen_proof(vec![*positions.choose(&mut rng).unwrap()]));
     });
 
     c.bench_function("MMR gen node-proof", |b| {
-        let (mmr_size, store, positions) = prepare_mmr_no_roots(100_000);
+        let (mmr_size, store, positions) = prepare_mmr_no_roots(20_000_000);
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         b.iter(|| mmr.gen_node_proof(vec![*positions.choose(&mut rng).unwrap()]));
     });
 
     c.bench_function("MMR gen ancestry-proof", |b| {
-        let (mmr_size, store, _positions, roots) = prepare_mmr_with_roots(100_000);
+        let (mmr_size, store, _positions, roots) = prepare_mmr_with_roots(50_000);
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         b.iter(|| mmr.gen_ancestry_proof(roots.choose(&mut rng).unwrap().0 as u64));
     });
 
     c.bench_function("MMR verify", |b| {
-        let (mmr_size, store, positions) = prepare_mmr_no_roots(100_000);
+        let (mmr_size, store, positions) = prepare_mmr_no_roots(20_000_000);
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         let root: NumberHash = mmr.get_root().unwrap();
-        let proofs: Vec<_> = (0..10_000)
+        let proofs: Vec<_> = (0..100_000)
             .map(|_| {
                 let pos = positions.choose(&mut rng).unwrap();
                 let elem = (&store).get_elem(*pos).unwrap().unwrap();
@@ -139,7 +139,7 @@ fn bench(c: &mut Criterion) {
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         let root: NumberHash = mmr.get_root().unwrap();
-        let proofs: Vec<_> = (0..10_000)
+        let proofs: Vec<_> = (0..100_000)
             .map(|_| {
                 let pos = positions.choose(&mut rng).unwrap();
                 let elem = (&store).get_elem(*pos).unwrap().unwrap();
@@ -156,11 +156,11 @@ fn bench(c: &mut Criterion) {
     });
 
     c.bench_function("MMR verify ancestry-proof", |b| {
-        let (mmr_size, store, _positions, roots) = prepare_mmr_with_roots(100_000);
+        let (mmr_size, store, _positions, roots) = prepare_mmr_with_roots(50_000);
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         let root: NumberHash = mmr.get_root().unwrap();
-        let proofs: Vec<_> = (0..10_000)
+        let proofs: Vec<_> = (0..50_000)
             .map(|_| {
                 let (prev_size, prev_root) = roots.choose(&mut rng).unwrap();
                 let proof = mmr.gen_ancestry_proof(*prev_size as u64).unwrap();
@@ -178,7 +178,7 @@ fn bench(c: &mut Criterion) {
 
 criterion_group!(
     name = benches;
-    config = Criterion::default().sample_size(20);
+    config = Criterion::default().sample_size(10);
     targets = bench
 );
 criterion_main!(benches);

--- a/benches/mmr_benchmark.rs
+++ b/benches/mmr_benchmark.rs
@@ -87,9 +87,18 @@ fn prepare_mmr_with_roots(
     (mmr_size, store, positions, roots.unwrap())
 }
 
-const MMR_LEAF_COUNT_NO_ROOTS: u32 = 200_000;
+const MMR_LEAF_COUNT_NO_ROOTS: u32 = if cfg!(feature = "production-bench") {
+    20_000_000
+} else {
+    200_000
+};
 // lower leaf count when retaining roots due to high memory load
-const MMR_LEAF_COUNT_WITH_ROOTS: u32 = 50_000;
+const MMR_LEAF_COUNT_WITH_ROOTS: u32 = if cfg!(feature = "production-bench") {
+    500_000
+} else {
+    50_000
+};
+
 
 fn bench(c: &mut Criterion) {
     c.bench_function("MMR gen proof", |b| {
@@ -205,7 +214,8 @@ fn bench(c: &mut Criterion) {
     });
 
     c.bench_function("MMR verify ancestry-proof", |b| {
-        let (mmr_size, store, _positions, roots) = prepare_mmr_with_roots(50_000);
+        let (mmr_size, store, _positions, roots) =
+            prepare_mmr_with_roots(MMR_LEAF_COUNT_WITH_ROOTS);
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
         let root: NumberHash = mmr.get_root().unwrap();
@@ -226,7 +236,7 @@ fn bench(c: &mut Criterion) {
 
 criterion_group!(
     name = benches;
-    config = Criterion::default().sample_size(20);
+    config = Criterion::default().sample_size(if cfg!(feature = "production-bench") {10} else {20});
     targets = bench
 );
 criterion_main!(benches);

--- a/benches/mmr_benchmark.rs
+++ b/benches/mmr_benchmark.rs
@@ -88,13 +88,13 @@ fn prepare_mmr_with_roots(
 }
 
 const MMR_LEAF_COUNT_NO_ROOTS: u32 = if cfg!(feature = "production-bench") {
-    20_000_000
+    40_000_000
 } else {
     200_000
 };
 // lower leaf count when retaining roots due to high memory load
 const MMR_LEAF_COUNT_WITH_ROOTS: u32 = if cfg!(feature = "production-bench") {
-    500_000
+    1_000_000
 } else {
     50_000
 };


### PR DESCRIPTION
Extracts the benching extensions from https://github.com/Lederstrumpf/merkle-mountain-range/tree/bench_comparison_refactor, as used for the comparison here: https://github.com/paritytech/merkle-mountain-range/pull/7#discussion_r1753177310. These benches should be useful for future refactoring work.

This PR only increases the default MMR leaf count in the benches by a factor of two rather than fully up to 20M (as used in the comparison mentioned above) since this eats a couple dozen GB of RAM and would take inordinately long to run on most systems.
Running with a leaf count on the order of 20M is recommended though prior to merging any changes materially impacting performance since this reference value gives a good indication of performance scaling when used in BEEFY's context on Polkadot/Kusama.
